### PR TITLE
optimize: Introduce ParticipantAvatar component for optimized avatar loading in leaderboard.

### DIFF
--- a/app/components/dashboard-components/ParticipantAvatar.tsx
+++ b/app/components/dashboard-components/ParticipantAvatar.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from '@/app/components/ui/avatar';
+import { useEffect, useRef, useState } from 'react';
+
+interface ParticipantAvatarProps {
+  username: string;
+  className?: string;
+}
+
+const ParticipantAvatar = ({ username, className }: ParticipantAvatarProps) => {
+  const [isIntersecting, setIsIntersecting] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsIntersecting(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <Avatar
+      ref={ref}
+      className={className}
+    >
+      {isIntersecting ? (
+        <AvatarImage
+          src={`https://github.com/${username}.png`}
+          alt={`${username}'s avatar`}
+          loading="lazy"
+        />
+      ) : null}
+      <AvatarFallback>
+        <img
+          src="/icon_badge.png"
+          alt="Fallback"
+          loading="lazy"
+          className="w-full h-full"
+        />
+      </AvatarFallback>
+    </Avatar>
+  );
+};
+
+export default ParticipantAvatar;

--- a/app/components/dashboard-components/leaderboard.tsx
+++ b/app/components/dashboard-components/leaderboard.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react';
 import { FaSort, FaSortDown, FaSortUp } from 'react-icons/fa'; // Import sorting icons
 import { MdCode, MdMonetizationOn } from 'react-icons/md';
 import { Card, CardDescription, CardHeader } from '../ui/card';
+import ParticipantAvatar from './ParticipantAvatar';
 
 export type TUserData = {
   fullName: string;
@@ -290,11 +291,7 @@ const Leaderboard = ({ user }: { user: AuthUser | null }) => {
             >
               <div className="flex flex-grow items-center gap-3 md:w-[50%]">
                 <div className="relative">
-                  <img
-                    src={`https://github.com/${data.username}.png`}
-                    alt={`${data.username}'s avatar`}
-                    className="h-8 w-8 rounded-full"
-                  />
+                  <ParticipantAvatar username={data.username} />
                   <span className="absolute -top-1 -left-1 flex h-5 w-5 items-center justify-center rounded-full bg-gray-900 text-xs font-semibold text-white ring-1 ring-white/30">
                     {index + 1}
                   </span>

--- a/app/components/rfc-components/readmeviewer.tsx
+++ b/app/components/rfc-components/readmeviewer.tsx
@@ -102,21 +102,9 @@ const ReadmeViewer = ({ owner, repoName, pdfLink }: ReadmeViewerProps) => {
 
   return (
     <Card className="bg-white/20 backdrop-blur-md border border-white/30 shadow-sm h-full flex flex-col">
-      <CardContent className="flex-1 flex flex-col mt-8">
-        <div className="prose prose-lg max-w-none prose-headings:text-gray-900 prose-headings:font-bold prose-p:text-gray-800 prose-p:font-medium prose-strong:text-gray-900 prose-strong:font-bold prose-code:text-gray-700 prose-code:bg-gray-100/50 prose-code:px-2 prose-code:py-1 prose-code:rounded prose-code:font-semibold prose-pre:bg-gray-100/50 prose-pre:border prose-pre:border-gray-200/50 prose-pre:text-gray-700 prose-a:text-blue-600 prose-a:hover:text-blue-500 prose-a:font-semibold prose-li:text-gray-800 prose-li:font-medium prose-blockquote:text-gray-600 prose-blockquote:border-l-gray-400 flex-1 overflow-y-auto">
-          {readmeContent ? (
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {readmeContent}
-            </ReactMarkdown>
-          ) : (
-            <div className="text-center text-gray-600">
-              <FileText className="mx-auto mb-2 h-8 w-8 text-gray-600" />
-              <p>No README content available.</p>
-            </div>
-          )}
-        </div>
+      <CardContent className="flex-1 flex flex-col bg-accent rounded-xl p-4">
         {pdfLink && (
-          <div className="mt-4 flex flex-col items-start">
+          <div className="mt-4 mb-16 flex flex-col items-start">
             <p className="text-gray-800 mb-2">
               Additional project details are available in the PDF document.
             </p>
@@ -135,6 +123,18 @@ const ReadmeViewer = ({ owner, repoName, pdfLink }: ReadmeViewerProps) => {
             </Button>
           </div>
         )}
+        <div className="prose prose-lg max-w-none flex-1 overflow-y-auto bg-accent/40 prose-a:text-blue-600 prose-a:hover:text-blue-500 prose-a:font-semibold prose-li:text-gray-800 prose-li:font-medium prose-blockquote:text-gray-600 prose-blockquote:border-l-gray-400">
+          {readmeContent ? (
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {readmeContent}
+            </ReactMarkdown>
+          ) : (
+            <div className="text-center text-gray-600">
+              <FileText className="mx-auto mb-2 h-8 w-8 text-gray-600" />
+              <p>No README content available.</p>
+            </div>
+          )}
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
GitHub images of participants will be fetched in participant list only on user seeing the participant row.

This will prevent us from getting rate-limited by GitHub.

Also this is updated RFC Markdown.

![image](https://github.com/user-attachments/assets/4a361374-b80c-4575-94d7-a86a8bcb08e7)
